### PR TITLE
Add deterministic port setup for git worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,11 @@ Worktrees from different repos that happen to share a directory name will get th
 Make sure your framework config reads `process.env.APP_PORT` and that you've loaded dotenv (or your framework does it automatically). See [framework examples](#framework-examples).
 
 **Script fails on Linux**
-Requires Bash 4+. Some minimal Docker images ship with Bash 3 or only `sh`. Install Bash 4+ or use a base image that includes it.
+Requires Bash 3.2+. Some minimal Docker images only ship `sh`. Install Bash or use a base image that includes it.
 
 ## Requirements
 
-- Bash 4+
+- Bash 3.2+
 - Git (for automatic main worktree detection)
 - Runs on macOS and Linux
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ When tools like [Conductor](https://conductor.build), [OpenAI Codex](https://ope
 ## Quick start
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/kevinmaes/worktree-ports/main/setup-env.sh | bash
+curl -fsSL https://raw.githubusercontent.com/kevinmaes/worktree-ports/main/setup-env.sh | bash
 ```
 
 The script will:
@@ -25,7 +25,7 @@ Add the script to your `conductor.json` setup hook:
 ```json
 {
   "scripts": {
-    "setup": "curl -sSL https://raw.githubusercontent.com/kevinmaes/worktree-ports/main/setup-env.sh | bash && pnpm install"
+    "setup": "curl -fsSL https://raw.githubusercontent.com/kevinmaes/worktree-ports/main/setup-env.sh | bash && pnpm install"
   }
 }
 ```
@@ -37,14 +37,14 @@ Conductor runs `setup` automatically when creating a new workspace. The script u
 Add the script to your environment setup. In your Codex cloud environment config or local setup, run it as part of your project initialization:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/kevinmaes/worktree-ports/main/setup-env.sh | bash
+curl -fsSL https://raw.githubusercontent.com/kevinmaes/worktree-ports/main/setup-env.sh | bash
 ```
 
 You can also mention it in your `AGENTS.md` so Codex knows to run it when creating worktrees:
 
 ```markdown
 ## Environment setup
-Run `curl -sSL https://raw.githubusercontent.com/kevinmaes/worktree-ports/main/setup-env.sh | bash`
+Run `curl -fsSL https://raw.githubusercontent.com/kevinmaes/worktree-ports/main/setup-env.sh | bash`
 after creating a worktree to assign a unique dev server port.
 The port is written to `.env` as `APP_PORT`.
 ```
@@ -56,7 +56,7 @@ Run the script after creating a worktree:
 ```bash
 git worktree add ../my-feature
 cd ../my-feature
-curl -sSL https://raw.githubusercontent.com/kevinmaes/worktree-ports/main/setup-env.sh | bash
+curl -fsSL https://raw.githubusercontent.com/kevinmaes/worktree-ports/main/setup-env.sh | bash
 pnpm install
 ```
 

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -68,7 +68,7 @@ djb2_hash() {
   local hash=5381
   for (( i = 0; i < ${#str}; i++ )); do
     char=$(printf '%d' "'${str:$i:1}")
-    hash=$(( (hash * 33 + char) % 2147483647 ))
+    hash=$(( (hash * 33 + char) % 2147483647 )) # 2^31-1: prevent bash integer overflow
   done
   echo $(( hash % 1000 + 4000 ))
 }

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -81,7 +81,7 @@ upsert_env_var() {
   local value="$2"
   local file=".env"
   if grep -q "^${key}=" "$file"; then
-    # macOS sed requires -i '' ; Linux sed requires -i without arg.
+    # BSD sed requires -i '' ; GNU sed requires -i without arg.
     if [[ "$(uname)" == "Darwin" ]]; then
       sed -i '' "s|^${key}=.*|${key}=${value}|" "$file" || { echo "$PREFIX Error: failed to update ${key} in $file"; exit 1; }
     else

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Deterministic per-worktree port assignment for parallel development tools.
 # Works with Conductor, OpenAI Codex, manual git worktrees, and more.
 #
-# Usage: curl -sSL https://raw.githubusercontent.com/kevinmaes/worktree-ports/main/setup-env.sh | bash
+# Usage: curl -fsSL https://raw.githubusercontent.com/kevinmaes/worktree-ports/main/setup-env.sh | bash
 #
 # What it does:
 # 1. Copies .env from the main worktree into the current worktree

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 # .env copy resolution order:
 #   1. CONDUCTOR_ROOT_PATH (set automatically by Conductor)
 #   2. Main git worktree (detected via `git worktree list`)
+#   3. Falls back to any .env already present in the workspace
 #
 # Environment variables written to .env:
 #   APP_PORT - the deterministic port number (4000-4999)

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # What it does:
 # 1. Copies .env from the main worktree into the current worktree
 # 2. Hashes the worktree directory name to a deterministic port in 4000-4999
-# 3. Writes APP_PORT=<port> into .env (creates or updates)
+# 3. Writes APP_PORT=<port> into .env (adds the key or updates it if present)
 #
 # .env copy resolution order:
 #   1. CONDUCTOR_ROOT_PATH (set automatically by Conductor)

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -55,7 +55,8 @@ if [[ "$env_copied" == false ]]; then
   echo "$PREFIX No source .env found (checked CONDUCTOR_ROOT_PATH and main worktree)"
 fi
 
-# Only assign a port if .env exists (either copied above or already present)
+# Only assign a port if .env exists (either copied above or already present).
+# Exit 0 intentionally: missing .env is not an error, it just means there's nothing to do.
 if [[ ! -f .env ]]; then
   echo "$PREFIX No .env file found, skipping port assignment"
   exit 0


### PR DESCRIPTION
## Summary

- Adds `setup-env.sh`: a bash script that copies `.env` from the main worktree and assigns a deterministic `APP_PORT` (4000-4999) based on the directory name using djb2 hashing
- Works with Conductor (`CONDUCTOR_ROOT_PATH`), OpenAI Codex, and manual `git worktree` workflows
- Includes comprehensive README with framework examples (Vite, Next.js, Express, Remix), setup guides per tool, and troubleshooting
- Robust error handling: surfaces `git worktree list` failures, provides context on `cp`/`sed` errors, and validates parsed paths

## Test plan

- [ ] Run `bash setup-env.sh` in a worktree with a `.env` in the main worktree and verify `APP_PORT` is written
- [ ] Run without `CONDUCTOR_ROOT_PATH` set and verify `git worktree list` fallback works
- [ ] Run in a non-worktree directory and verify graceful `exit 0`
- [ ] Re-run to confirm idempotent `APP_PORT` update (same value, no duplicates)
- [ ] Verify on both macOS (BSD sed) and Linux (GNU sed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)